### PR TITLE
Always create $env:USERPROFILE\.hvtoolscfgpath

### DIFF
--- a/Intune.HV.Tools/Private/Get-AutopilotPolicy.ps1
+++ b/Intune.HV.Tools/Private/Get-AutopilotPolicy.ps1
@@ -33,7 +33,8 @@ function Get-AutopilotPolicy {
             else {
                 if ($apPolicies.count -gt 1) {
                     Write-Host "Multiple Autopilot policies found - select the correct one.." -ForegroundColor Cyan
-                    $apPol = $apPolicies | Select-Object displayName | Out-GridView -passthru
+                    $selectedAp = $apPolicies | Select-Object displayName | Out-GridView -passthru
+                    $apPol = $apPolicies | Where-Object {$_.displayName -eq $selectedAp.displayName}
                 }
                 else {
                     Write-Host "Policy found - saving to $FileDestination.." -ForegroundColor Cyan

--- a/Intune.HV.Tools/Public/Add-ImageToConfig.ps1
+++ b/Intune.HV.Tools/Public/Add-ImageToConfig.ps1
@@ -19,7 +19,7 @@ function Add-ImageToConfig {
             refImagePath = $ReferenceVHDX
         }
         $script:hvConfig.images += $newTenant
-        $script:hvConfig | ConvertTo-Json -Depth 20 | Out-File -FilePath $hvConfig.hvConfigPath -Encoding ascii -Force
+        $script:hvConfig | ConvertTo-Json -Depth 20 | Out-File -FilePath $script:hvConfig.hvConfigPath -Encoding ascii -Force
         Write-Host $script:tick -ForegroundColor Green
         #region Check for ref image - if it's not there, build it
         if (!(Test-Path -Path $newTenant.refImagePath -ErrorAction SilentlyContinue)) {

--- a/Intune.HV.Tools/Public/Add-NetworkToConfig.ps1
+++ b/Intune.HV.Tools/Public/Add-NetworkToConfig.ps1
@@ -13,7 +13,7 @@ function Add-NetworkToConfig {
         if ($VLanId) {
             $script:hvConfig.vLanId = $VLanId
         }
-        $script:hvConfig | ConvertTo-Json -Depth 20 | Out-File -FilePath $hvConfig.hvConfigPath -Encoding ascii -Force
+        $script:hvConfig | ConvertTo-Json -Depth 20 | Out-File -FilePath $script:hvConfig.hvConfigPath -Encoding ascii -Force
     }
     catch {
         $errorMsg = $_

--- a/Intune.HV.Tools/Public/Add-TenantToConfig.ps1
+++ b/Intune.HV.Tools/Public/Add-TenantToConfig.ps1
@@ -18,7 +18,7 @@ function Add-TenantToConfig {
             AdminUpn   = $AdminUpn
         }
         $script:hvConfig.tenantConfig += $newTenant
-        $script:hvConfig | ConvertTo-Json -Depth 20 | Out-File -FilePath $hvConfig.hvConfigPath -Encoding ascii -Force
+        $script:hvConfig | ConvertTo-Json -Depth 20 | Out-File -FilePath $script:hvConfig.hvConfigPath -Encoding ascii -Force
     }
     catch {
         $errorMsg = $_

--- a/Intune.HV.Tools/Public/Initialize-HVTools.ps1
+++ b/Intune.HV.Tools/Public/Initialize-HVTools.ps1
@@ -22,23 +22,18 @@ function Initialize-HVTools {
         }
         $cfgPath = "$Path\.hvtools\hvconfig.json"
         Write-Host " + Creating $cfgPath.. " -ForegroundColor Cyan -NoNewline
-        if ((Test-Path $cfgPath -ErrorAction SilentlyContinue) -and ($Reset -eq $false)) {
-            Write-Host "$script:tick (Already created - no need to run this again..)" -ForegroundColor Green
-        }
-        else {
-            $initCfg = @{
-                'hvConfigPath' = $cfgPath
-                'images'       = @()
-                "vmPath"       = "$Path\.hvtools\tenantVMs"
-                'vSwitchName'  = $null
-                'vLanId'       = $null
-                'tenantConfig' = @()
-            } | ConvertTo-Json -Depth 20
-            $initCfg | Out-File $cfgPath -Encoding ascii -Force
-            $cfgPath | Out-File "$env:USERPROFILE\.hvtoolscfgpath" -Encoding ascii -Force
-            Write-Host $script:tick -ForegroundColor Green
-            $script:hvConfig = (get-content -Path "$(get-content "$env:USERPROFILE\.hvtoolscfgpath" -ErrorAction SilentlyContinue)" -raw -ErrorAction SilentlyContinue | ConvertFrom-Json)
-        }
+        $initCfg = @{
+            'hvConfigPath' = $cfgPath
+            'images'       = @()
+            "vmPath"       = "$Path\.hvtools\tenantVMs"
+            'vSwitchName'  = $null
+            'vLanId'       = $null
+            'tenantConfig' = @()
+        } | ConvertTo-Json -Depth 20
+        $initCfg | Out-File $cfgPath -Encoding ascii -Force
+        $cfgPath | Out-File "$env:USERPROFILE\.hvtoolscfgpath" -Encoding ascii -Force
+        Write-Host $script:tick -ForegroundColor Green
+        $script:hvConfig = (get-content -Path "$(get-content "$env:USERPROFILE\.hvtoolscfgpath" -ErrorAction SilentlyContinue)" -raw -ErrorAction SilentlyContinue | ConvertFrom-Json)
     }
     catch {
         Write-Warning $_


### PR DESCRIPTION
When use this function initialize a new folder, it didn't update "$env:USERPROFILE\.hvtoolscfgpath" file content, or recreate this new file, so reads hvconfig.json configuration from wrong folder. I think "$env:USERPROFILE\.hvtoolscfgpath" file need to be updated when run this function. 

In my example, I first run " Initialize-HVTools -Path "D:\Hyper-V\DEMO1", when want to use a new folder by using  Initialize-HVTools -Path "D:\Hyper-V\DEMO", it reads hvconfig.json path from .hvtoolscfgpath, which it goes to the DEMO1 folder, not DEMO folder.

PS C:\Windows\system32> Initialize-HVTools -Path "D:\Hyper-V\DEMO"
Add-ImageToConfig -ImageName "2004" -IsoPath "D:\No-Dedup\Asennus\ISO\en_windows_10_business_editions_version_2004_updated_june_2020_x64_dvd_cc9defea.iso"
Add-TenantToConfig -TenantName "Contoso" -ImageName "2004" -AdminUpn "admin@M365x810560.onmicrosoft.com"
Add-NetworkToConfig -VSwitchName 'CrazyNet'
New-ClientVM -TenantName 'Contoso' -NumberOfVMs 1 -CPUsPerVM 1 -VMMemory 2gb -Verbose
Creating hvtools folder structure..
 + Creating D:\Hyper-V\DEMO\.hvtools\hvconfig.json.. √ (Already created - no need to run this again..)
Adding 2004 to config.. √
Creating reference Autopilot VHDX - this may take some time..
Select an Image from the below available options:

ImageIndex ImageName                        
---------- ---------                        
         1 Windows 10 Education             
         2 Windows 10 Education N           
         3 Windows 10 Enterprise            
         4 Windows 10 Enterprise N          
         5 Windows 10 Pro                   
         6 Windows 10 Pro N                 
         7 Windows 10 Pro Education         
         8 Windows 10 Pro Education N       
         9 Windows 10 Pro for Workstations  
        10 Windows 10 Pro N for Workstations



Select Image Index..(1..10): 3
Image 3 / Windows 10 Enterprise selected..

Building reference image..√
Adding Contoso to config.. √
Adding virtual switch details to config.. √
VERBOSE: Autopilot Reference VHDX: 
VERBOSE: Client name: Contoso
VERBOSE: Win10 ISO is located:  
VERBOSE: Path to client VMs will be: D:\Hyper-V\DEMO1\.hvtools\tenantVMs\Contoso
VERBOSE: Number of VMs to create:  1
VERBOSE: Admin user for Contoso is:  admin@M365x810560.onmicrosoft.com admin@M365x810560.onmicrosoft.com

WARNING: Cannot bind argument to parameter 'Path' because it is null.
