### PR TITLE
Always confirm tenant for connect-graph, confirm Autopilot config exists.

### DIFF
--- a/Intune.HV.Tools/Private/Get-AutopilotPolicy.ps1
+++ b/Intune.HV.Tools/Private/Get-AutopilotPolicy.ps1
@@ -8,6 +8,7 @@ function Get-AutopilotPolicy {
     )
     try {
         if (!(Test-Path "$FileDestination\AutopilotConfigurationFile.json" -ErrorAction SilentlyContinue)) {
+            Write-Host "Autopilot Configuration file not found.." -ForegroundColor Red
             $modules = @(
                 "WindowsAutoPilotIntune",
                 "Microsoft.Graph.Intune"
@@ -23,7 +24,8 @@ function Get-AutopilotPolicy {
                 }
             }
             #region Connect to Intune
-            Connect-MSGraph | Out-Null
+            ## Require user to confirm which tenant they want to use, in case the user uses multiple.
+            Connect-MSGraph -ForceInteractive  | Out-Null
             #endregion Connect to Intune
             #region Get policies
             $apPolicies = Get-AutopilotProfile

--- a/Intune.HV.Tools/Public/New-ClientVM.ps1
+++ b/Intune.HV.Tools/Public/New-ClientVM.ps1
@@ -34,7 +34,7 @@ function New-ClientVM {
             $imageDetails = $script:hvConfig.images | Where-Object { $_.imageName -eq $clientDetails.imageName }
         }
         $clientPath = "$($script:hvConfig.vmPath)\$($TenantName)"
-        if($imageDetails.refimagePath -like '*wks$($ImageName)ref.vhdx'){
+        if ($imageDetails.refimagePath -like '*wks$($ImageName)ref.vhdx') {
             if (!(Test-Path $imageDetails.imagePath -ErrorAction SilentlyContinue)) {
                 throw "Installation media not found at location: $($imageDetails.imagePath)"
             }
@@ -62,6 +62,10 @@ function New-ClientVM {
         if (!($SkipAutoPilot)) {
             Write-Host "Grabbing Autopilot config.." -ForegroundColor Yellow
             Get-AutopilotPolicy -FileDestination "$clientPath"
+        }
+        if (!(Test-Path "$clientPath\AutopilotConfigurationFile.json" -ErrorAction SilentlyContinue)) {
+            throw "Autopilot config not found.."
+
         }
         #endregion
         #region Build the client VMs

--- a/Intune.HV.Tools/Public/New-ClientVM.ps1
+++ b/Intune.HV.Tools/Public/New-ClientVM.ps1
@@ -65,7 +65,6 @@ function New-ClientVM {
         }
         if (!(Test-Path "$clientPath\AutopilotConfigurationFile.json" -ErrorAction SilentlyContinue)) {
             throw "Autopilot config not found.."
-
         }
         #endregion
         #region Build the client VMs

--- a/Intune.HV.Tools/Public/New-ClientVM.ps1
+++ b/Intune.HV.Tools/Public/New-ClientVM.ps1
@@ -62,9 +62,9 @@ function New-ClientVM {
         if (!($SkipAutoPilot)) {
             Write-Host "Grabbing Autopilot config.." -ForegroundColor Yellow
             Get-AutopilotPolicy -FileDestination "$clientPath"
-        }
-        if (!(Test-Path "$clientPath\AutopilotConfigurationFile.json" -ErrorAction SilentlyContinue)) {
-            throw "Autopilot config not found.."
+            if (!(Test-Path "$clientPath\AutopilotConfigurationFile.json" -ErrorAction SilentlyContinue)) {
+                throw "Autopilot config not found.."
+            }
         }
         #endregion
         #region Build the client VMs


### PR DESCRIPTION
I encountered times when I ran **New-ClientVm** and I was already authenticated to _Tenant A_ via **Connect-Graph** but I wanted to create a ClientVm for _Tenant B_ and I also need to create a new Autopilot config for _Tenant B_. The **Connect-Graph** step seems to get skipped and I am not then able to authenticate to _Tenant B_ and no Autopilot config is created.
Adding a **-ForceInteractive** to **Connect-Graph** solved this in my trial runs by requiring me to select which account to use.
Additionally I added a throw in **New-ClientVM.ps1** in case the Autopilot config is not found.

My apologies if I am missed something. This is my first ever pull request.
