### PR TITLE
fix: Enable-VMIntegrationService fails on non Englisch systems

### DIFF
--- a/Intune.HV.Tools/Private/New-ClientDevice.ps1
+++ b/Intune.HV.Tools/Private/New-ClientDevice.ps1
@@ -31,7 +31,7 @@ function New-ClientDevice {
     }
 
     New-VM -Name $VMName -MemoryStartupBytes $VMMMemory -VHDPath "$ClientPath\$VMName.vhdx" -Generation 2 | Out-Null
-    Enable-VMIntegrationService -vmName $VMName -Name "Guest Service Interface"
+    Get-VMIntegrationService -vmName $VMName | ? Name -match 'Interface' | Enable-VMIntegrationService
     Set-VM -name $VMName -CheckpointType Disabled
     Set-VMProcessor -VMName $VMName -Count $CPUCount
     Set-VMFirmware -VMName $VMName -EnableSecureBoot On


### PR DESCRIPTION
Enable-VMIntegrationService depends on the OS language and fails on non Englisch systems:

Error on German OS:
````
~ $ Enable-VMIntegrationService -vmName CompuGlobalHyperMegaNet_1 -Name "Guest Service Interface"
Enable-VMIntegrationService: Es wurde keine Integrationskomponente mit dem angegebenen Namen gefunden.
````

Credit for the fix goes to: https://dojoforums.altaro.com/topic/enabling-guest-service-interface-with-powershell-invalidargument-error/